### PR TITLE
Krops deployment

### DIFF
--- a/krops.nix
+++ b/krops.nix
@@ -17,7 +17,7 @@ let
     };
 
     # Copy repository to /var/src
-    machine-config.file = toString ../nixos;
+    machine-config.file = toString ./.;
   }];
 in {
 

--- a/krops.nix
+++ b/krops.nix
@@ -1,0 +1,33 @@
+let
+  krops = (import <nixpkgs> {}).fetchgit {
+    url = https://cgit.krebsco.de/krops/;
+    rev = "v1.17.0";
+    sha256 = "150jlz0hlb3ngf9a1c9xgcwzz1zz8v2lfgnzw08l3ajlaaai8smd";
+  };
+
+  lib = import "${krops}/lib";
+  pkgs = import "${krops}/pkgs" {};
+
+  source = lib.evalSource [{
+
+    # You might want to set your nixpkgs branch here
+    nixpkgs.git = {
+      ref = "origin/nixos-20.09";
+      url = https://github.com/NixOS/nixpkgs;
+    };
+
+    # Use the existing confiruatio.nix file as base
+    nixos-config.file = toString ./configuration.nix;
+  }];
+in
+
+  # Create a deploment for localhost. You can define multiple hosts here, with
+  # arbitrary names
+  pkgs.krops.writeDeploy "deploy-localhost" {
+    source = source;
+    # You can use arbitrary targets here, as long as SSH is correctly
+    # configured
+    target = "root@localhost";
+  }
+
+# https://tech.ingolf-wagner.de/nixos/krops/

--- a/krops.nix
+++ b/krops.nix
@@ -16,8 +16,8 @@ let
       url = "https://github.com/NixOS/nixpkgs";
     };
 
-    # Use the existing confiruatio.nix file as base
-    nixos-config.file = toString ./configuration.nix;
+    # Copy repository to /var/src
+    machine-config.file = toString ../nixos;
   }];
 in {
 

--- a/krops.nix
+++ b/krops.nix
@@ -10,12 +10,6 @@ let
 
   source = lib.evalSource [{
 
-    # You might want to set your nixpkgs branch here
-    nixpkgs.git = {
-      ref = "origin/nixos-unstable";
-      url = "https://github.com/NixOS/nixpkgs";
-    };
-
     # Copy repository to /var/src
     machine-config.file = toString ./.;
   }];

--- a/krops.nix
+++ b/krops.nix
@@ -12,7 +12,7 @@ let
 
     # You might want to set your nixpkgs branch here
     nixpkgs.git = {
-      ref = "origin/nixos-20.09";
+      ref = "origin/nixos-unstable";
       url = "https://github.com/NixOS/nixpkgs";
     };
 

--- a/krops.nix
+++ b/krops.nix
@@ -1,33 +1,50 @@
 let
-  krops = (import <nixpkgs> {}).fetchgit {
-    url = https://cgit.krebsco.de/krops/;
+  krops = (import <nixpkgs> { }).fetchgit {
+    url = "https://cgit.krebsco.de/krops/";
     rev = "v1.17.0";
     sha256 = "150jlz0hlb3ngf9a1c9xgcwzz1zz8v2lfgnzw08l3ajlaaai8smd";
   };
 
   lib = import "${krops}/lib";
-  pkgs = import "${krops}/pkgs" {};
+  pkgs = import "${krops}/pkgs" { };
 
   source = lib.evalSource [{
 
     # You might want to set your nixpkgs branch here
     nixpkgs.git = {
       ref = "origin/nixos-20.09";
-      url = https://github.com/NixOS/nixpkgs;
+      url = "https://github.com/NixOS/nixpkgs";
     };
 
     # Use the existing confiruatio.nix file as base
     nixos-config.file = toString ./configuration.nix;
   }];
-in
+in {
 
   # Create a deploment for localhost. You can define multiple hosts here, with
   # arbitrary names
-  pkgs.krops.writeDeploy "deploy-localhost" {
+  localhost = pkgs.krops.writeDeploy "deploy-localhost" {
     source = source;
     # You can use arbitrary targets here, as long as SSH is correctly
     # configured
     target = "root@localhost";
-  }
+  };
 
-# https://tech.ingolf-wagner.de/nixos/krops/
+  # Here is how you would add other machines:
+  #
+  # server02 = pkgs.krops.writeDeploy "deploy-server02" {
+  #    source = source;
+  #    target = "root@server01";
+  #  };
+
+  # server02 = pkgs.krops.writeDeploy "deploy-server02" {
+  #    source = source;
+  #    target = "root@server02.mydomain.org";
+  #  };
+
+  # Full example:
+  # https://tech.ingolf-wagner.de/nixos/krops/
+
+  # Deploy with (e.g. for server01:
+  # nix-build ./krops.nix -A server01 && ./result
+}


### PR DESCRIPTION
Add most basic form of deployment with `krops`.

Test before merging!

To run the deployment use:
```
nix-build ./krops.nix -A deploy-localhost && ./result
```

Look at the comments in `krops.nix` for more information. Full example is here: https://tech.ingolf-wagner.de/nixos/krops/
