### PR TITLE
↗️ Switched to flakes deployment

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,26 +8,29 @@ platform:
   arch: amd64
 
 steps:
-- name: Build water-on-fire
+- name: Show flake info
   image: nixpkgs/nix-flakes
   commands:
-  - nix-build ./krops.nix -A water-on-fire
+  - nix --experimental-features "nix-command flakes" flake show
+  - nix --experimental-features "nix-command flakes" flake info
+  - nix --experimental-features "nix-command flakes" flake list-inputs
   environment:
     NIX_PATH: nixpkgs=channel:nixos-unstable
 
-- name: Build quinjet
+- name: Run flake checks
   image: nixpkgs/nix-flakes
   commands:
-  - nix-build ./krops.nix -A quinjet
+  - nix --experimental-features "nix-command flakes" flake check --show-trace
   environment:
     NIX_PATH: nixpkgs=channel:nixos-unstable
-    
-- name: Build the-bus
+
+- name: Build all hosts
   image: nixpkgs/nix-flakes
   commands:
-  - nix-build ./krops.nix -A the-bus
+  - nix-build krops.nix -A all
   environment:
     NIX_PATH: nixpkgs=channel:nixos-unstable
+
 
 - name: notify
   image: drillster/drone-email
@@ -39,7 +42,3 @@ steps:
       from_secret: email_host
     password:
       from_secret: email_password
-  depends_on:
-  - Build water-on-fire
-  - Build quinjet
-  - Build the-bus

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1615236417,
-        "narHash": "sha256-ialggc4ff+coOaKIxreoynh+FPSs2cergePIQE1U8jE=",
+        "lastModified": 1615419569,
+        "narHash": "sha256-+ewB0sQGeoYryWZk2Ww2Lm/5jeqhlYTjGy6zEX2Mm1I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "57a7e5e2c53de58215fdac1910470bef36dd30cd",
+        "rev": "040ea28e448a93d24540b7cf2eda4b25300c5ab1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,69 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1615236417,
+        "narHash": "sha256-ialggc4ff+coOaKIxreoynh+FPSs2cergePIQE1U8jE=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "57a7e5e2c53de58215fdac1910470bef36dd30cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixos-home": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1615412259,
+        "narHash": "sha256-brNT7CfG/RI2rbLscFSOW5EbxE2sag0qujEzrqvpqu4=",
+        "owner": "mayniklas",
+        "repo": "nixos-home",
+        "rev": "b423f53d6c1d56b09f21895519cdbb05f71b253c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mayniklas",
+        "repo": "nixos-home",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1615259932,
+        "narHash": "sha256-IXecmbqCr+XCtFwzBO3tHEd8PoJ4X4EyPZebKbV2ioE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "29b0d4d0b600f8f5dd0b86e3362a33d4181938f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nixos-home": "nixos-home",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1615412259,
-        "narHash": "sha256-brNT7CfG/RI2rbLscFSOW5EbxE2sag0qujEzrqvpqu4=",
+        "lastModified": 1615415291,
+        "narHash": "sha256-j3cskLtn+qz62f+1z8fNLfK92BlZ+dl4HZ3uTY7vozU=",
         "owner": "mayniklas",
         "repo": "nixos-home",
-        "rev": "b423f53d6c1d56b09f21895519cdbb05f71b253c",
+        "rev": "4e8ef9c84cdced88f8ef3abdb0d2133359625c21",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,11 +11,98 @@
     nixos-home.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, home-manager, nixos-home }: {
+  outputs = { self, nixpkgs, home-manager, nixos-home }:
+    let
+      # Function to create defult (common) system config options
+      defFlakeSystem = baseCfg:
+        nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [
+            # Add home-manager option to all configs
+            ({ ... }: {
+              imports = [
+                {
+                  # Set the $NIX_PATH entry for nixpkgs. This is necessary in
+                  # this setup with flakes, otherwise commands like `nix-shell
+                  # -p pkgs.htop` will keep using an old version of nixpkgs.
+                  # With this entry in $NIX_PATH it is possible (and
+                  # recommended) to remove the `nixos` channel for both users
+                  # and root e.g. `nix-channel --remove nixos`. `nix-channel
+                  # --list` should be empty for all users afterwards
+                  nix.nixPath = [ "nixpkgs=${nixpkgs}" ];
+                }
+                baseCfg
+                home-manager.nixosModules.home-manager
+                # DONT set useGlobalPackages! It's not necessary in newer
+                # home-manager versions and does not work with configs using
+                # `nixpkgs.config`
+                { home-manager.useUserPackages = true; }
+              ];
+              # Let 'nixos-version --json' know the Git revision of this flake.
+              system.configurationRevision =
+                nixpkgs.lib.mkIf (self ? rev) self.rev;
+              nix.registry.nixpkgs.flake = nixpkgs;
+            })
+          ];
+        };
 
-    packages.x86_64-linux.hello = nixpkgs.legacyPackages.x86_64-linux.hello;
+      base-modules-server = [
+        ./users/nik.nix
+        { home-manager.users.nik = nixos-home.nixosModules.server; }
+        ../../modules/docker.nix
+        ../../modules/grub.nix
+        ../../modules/nix-common.nix
+        ../../modules/networking.nix
+        ../../modules/locale.nix
+        ../../modules/hosts.nix
+        ../../modules/openssh.nix
+        ../../modules/options.nix
+        ../../modules/zsh.nix
+      ];
 
-    defaultPackage.x86_64-linux = self.packages.x86_64-linux.hello;
+      base-modules-desktop = [
+        ./users/nik.nix
+        { home-manager.users.nik = nixos-home.nixosModules.desktop; }
+        ../../modules/bluetooth.nix
+        ../../modules/locale.nix
+        ../../modules/networking.nix
+        ../../modules/nix-common.nix
+        ../../modules/openssh.nix
+        ../../modules/options.nix
+        ../../modules/hosts.nix
+        ../../modules/sound.nix
+        ../../modules/docker.nix
+        ../../modules/xserver.nix
+        ../../modules/yubikey.nix
+        ../../modules/zsh.nix
+      ];
+    in {
 
-  };
+      nixosConfigurations = {
+
+        water-on-fire = defFlakeSystem {
+          imports = base-modules-desktop ++ [
+            # Machine specific config
+            ./machines/water-on-fire/configuration.nix
+            ./machines/water-on-fire/hardware-configuration.nix
+          ];
+        };
+
+        quinjet = defFlakeSystem {
+          imports = base-modules-server ++ [
+            # Machine specific config
+            ./machines/quinjet/configuration.nix
+            ./machines/quinjet/hardware-configuration.nix
+          ];
+        };
+
+        the-bus = defFlakeSystem {
+          imports = base-modules-server ++ [
+            # Machine specific config
+            ./machines/the-bus/configuration.nix
+            ./machines/the-bus/hardware-configuration.nix
+          ];
+        };
+      };
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -92,7 +92,6 @@
 
             # Modules
             ./modules/grub-luks.nix
-            ./modules/flakes.nix
             ./modules/nvidia.nix
           ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,7 @@
 
       base-modules-server = [
         ./users/nik.nix
+        ./users/root.nix
         { home-manager.users.nik = nixos-home.nixosModules.server; }
         ./modules/docker.nix
         ./modules/grub.nix
@@ -62,6 +63,7 @@
 
       base-modules-desktop = [
         ./users/nik.nix
+        ./users/root.nix
         { home-manager.users.nik = nixos-home.nixosModules.desktop; }
         ./modules/bluetooth.nix
         ./modules/locale.nix
@@ -85,10 +87,6 @@
             # Machine specific config
             ./machines/water-on-fire/configuration.nix
             ./machines/water-on-fire/hardware-configuration.nix
-
-            # Users
-            ./users/nik.nix
-            ./users/root.nix
 
             # Modules
             ./modules/grub-luks.nix

--- a/flake.nix
+++ b/flake.nix
@@ -99,6 +99,11 @@
             # Machine specific config
             ./machines/quinjet/configuration.nix
             ./machines/quinjet/hardware-configuration.nix
+
+            # Modules
+            ./modules/plex.nix
+            ./modules/containers/web-youtube-dl.nix
+            ./modules/containers/scene-extractor-AOS.nix
           ];
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -63,18 +63,18 @@
       base-modules-desktop = [
         ./users/nik.nix
         { home-manager.users.nik = nixos-home.nixosModules.desktop; }
-        ../../modules/bluetooth.nix
-        ../../modules/locale.nix
-        ../../modules/networking.nix
-        ../../modules/nix-common.nix
-        ../../modules/openssh.nix
-        ../../modules/options.nix
-        ../../modules/hosts.nix
-        ../../modules/sound.nix
-        ../../modules/docker.nix
-        ../../modules/xserver.nix
-        ../../modules/yubikey.nix
-        ../../modules/zsh.nix
+        ./modules/bluetooth.nix
+        ./modules/locale.nix
+        ./modules/networking.nix
+        ./modules/nix-common.nix
+        ./modules/openssh.nix
+        ./modules/hosts.nix
+        ./modules/options.nix
+        ./modules/sound.nix
+        ./modules/docker.nix
+        ./modules/xserver.nix
+        ./modules/yubikey.nix
+        ./modules/zsh.nix
       ];
     in {
 
@@ -85,6 +85,15 @@
             # Machine specific config
             ./machines/water-on-fire/configuration.nix
             ./machines/water-on-fire/hardware-configuration.nix
+
+            # Users
+            ./users/nik.nix
+            ./users/root.nix
+
+            # Modules
+            ./modules/grub-luks.nix
+            ./modules/flakes.nix
+            ./modules/nvidia.nix
           ];
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -49,15 +49,15 @@
       base-modules-server = [
         ./users/nik.nix
         { home-manager.users.nik = nixos-home.nixosModules.server; }
-        ../../modules/docker.nix
-        ../../modules/grub.nix
-        ../../modules/nix-common.nix
-        ../../modules/networking.nix
-        ../../modules/locale.nix
-        ../../modules/hosts.nix
-        ../../modules/openssh.nix
-        ../../modules/options.nix
-        ../../modules/zsh.nix
+        ./modules/docker.nix
+        ./modules/grub.nix
+        ./modules/nix-common.nix
+        ./modules/networking.nix
+        ./modules/locale.nix
+        ./modules/hosts.nix
+        ./modules/openssh.nix
+        ./modules/options.nix
+        ./modules/zsh.nix
       ];
 
       base-modules-desktop = [

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,17 @@
 {
   description = "A very basic flake";
 
-  outputs = { self, nixpkgs }: {
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+
+    nixos-home.url = "github:mayniklas/nixos-home";
+    nixos-home.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, home-manager, nixos-home }: {
 
     packages.x86_64-linux.hello = nixpkgs.legacyPackages.x86_64-linux.hello;
 

--- a/krops.nix
+++ b/krops.nix
@@ -47,8 +47,8 @@ in rec {
 
   # Groups
   all = pkgs.writeScript "deploy-all"
-    (lib.concatStringsSep "\n" [ water-on-fire quinjet the-bus ]);
+    (lib.concatStringsSep "\n" [ water-on-fire quinjet ]);
 
   servers = pkgs.writeScript "deploy-servers"
-    (lib.concatStringsSep "\n" [ quinjet the-bus ]);
+    (lib.concatStringsSep "\n" [ quinjet ]);
 }

--- a/machines/quinjet/configuration.nix
+++ b/machines/quinjet/configuration.nix
@@ -5,45 +5,14 @@
 { config, pkgs, ... }:
 
 {
-  imports = [
-    # Include the results of the hardware scan.
-    ./hardware-configuration.nix
-
-    # Users
-    ../../users/nik.nix
-    ../../users/root.nix
-
-    # Modules
-    ../../modules/docker.nix
-    ../../modules/grub.nix
-    ../../modules/nix-common.nix
-    ../../modules/networking.nix
-    ../../modules/locale.nix
-    ../../modules/hosts.nix
-    ../../modules/openssh.nix
-    ../../modules/options.nix
-    ../../modules/plex.nix
-    ../../modules/zsh.nix
-
-    # Containers
-    ../../modules/containers/web-youtube-dl.nix
-    ../../modules/containers/scene-extractor-AOS.nix
-  ];
 
   mainUser = "nik";
   mainUserHome = "${config.users.extraUsers.${config.mainUser}.home}";
   nasIP = "192.168.5.10";
 
-  networking = {
-    hostName = "quinjet";
-  };
+  networking = { hostName = "quinjet"; };
 
-  environment.systemPackages = with pkgs; [
-    bash-completion
-    git
-    nixfmt
-    wget
-  ];
+  environment.systemPackages = with pkgs; [ bash-completion git nixfmt wget ];
 
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions

--- a/machines/the-bus/configuration.nix
+++ b/machines/the-bus/configuration.nix
@@ -5,52 +5,14 @@
 { config, pkgs, ... }:
 
 {
-  imports = [
-    # Include the results of the hardware scan.
-    ./hardware-configuration.nix
-
-    # Users
-    ../../users/nik.nix
-    ../../users/root.nix
-
-    # Modules
-    ../../modules/docker.nix
-    ../../modules/networking.nix
-    ../../modules/locale.nix
-    ../../modules/hosts.nix
-    ../../modules/openssh.nix
-    ../../modules/options.nix
-    ../../modules/virtualization.nix
-    # ../../modules/plex.nix
-  ];
 
   mainUser = "nik";
   mainUserHome = "${config.users.extraUsers.${config.mainUser}.home}";
+  nasIP = "192.168.5.10";
 
-  networking = {
-    hostName = "the-bus";
-  };
+  networking = { hostName = "the-bus"; };
 
-  boot = {
-    loader = {
-      grub = {
-        enable = true;
-        version = 2;
-        device = "nodev";
-        efiSupport = true;
-      };
-      efi.canTouchEfiVariables = true;
-    };
-    cleanTmpDir = true;
-  };
-
-  environment.systemPackages = with pkgs; [
-    bash-completion
-    git
-    nixfmt
-    wget
-    htop
-  ];
+  environment.systemPackages = with pkgs; [ bash-completion git nixfmt wget ];
 
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions

--- a/machines/water-on-fire/configuration.nix
+++ b/machines/water-on-fire/configuration.nix
@@ -1,8 +1,7 @@
 # Edit this configuration file to define what should be installed on
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running ‘nixos-help’).
-{ config, pkgs, ... }:
-
+{ config, pkgs, ... }: {
 
   mainUser = "nik";
   mainUserHome = "${config.users.extraUsers.${config.mainUser}.home}";

--- a/machines/water-on-fire/configuration.nix
+++ b/machines/water-on-fire/configuration.nix
@@ -3,32 +3,6 @@
 # and in the NixOS manual (accessible by running ‘nixos-help’).
 { config, pkgs, ... }:
 
-{
-  imports = [
-    # Include the results of the hardware scan.
-    ./hardware-configuration.nix
-
-    # Users
-    ../../users/nik.nix
-    ../../users/root.nix
-
-    # Modules
-    ../../modules/grub-luks.nix
-    ../../modules/bluetooth.nix
-    ../../modules/flakes.nix
-    ../../modules/locale.nix
-    ../../modules/networking.nix
-    ../../modules/nix-common.nix
-    ../../modules/nvidia.nix
-    ../../modules/openssh.nix
-    ../../modules/options.nix
-    ../../modules/hosts.nix
-    ../../modules/sound.nix
-    ../../modules/docker.nix
-    ../../modules/xserver.nix
-    ../../modules/yubikey.nix
-    ../../modules/zsh.nix
-  ];
 
   mainUser = "nik";
   mainUserHome = "${config.users.extraUsers.${config.mainUser}.home}";

--- a/machines/water-on-fire/configuration.nix
+++ b/machines/water-on-fire/configuration.nix
@@ -1,10 +1,14 @@
 # Edit this configuration file to define what should be installed on
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running ‘nixos-help’).
-{ config, pkgs, ... }: {
+
+{ config, pkgs, ... }:
+
+{
 
   mainUser = "nik";
   mainUserHome = "${config.users.extraUsers.${config.mainUser}.home}";
+  nasIP = "192.168.5.10";
 
   # Get UUID from blkid /dev/sda2
   mayniklas = {

--- a/modules/flakes.nix
+++ b/modules/flakes.nix
@@ -1,8 +1,0 @@
-{ pkgs, ... }: {
-   nix = {
-    package = pkgs.nixFlakes;
-    extraOptions = ''
-      experimental-features = nix-command flakes
-    '';
-   };
-}

--- a/modules/nix-common.nix
+++ b/modules/nix-common.nix
@@ -4,6 +4,11 @@
 
   nix = {
 
+    package = pkgs.nixFlakes;
+    extraOptions = ''
+      experimental-features = nix-command flakes
+    '';
+
     # Save space by hardlinking store files
     autoOptimiseStore = true;
 

--- a/modules/nix-common.nix
+++ b/modules/nix-common.nix
@@ -1,5 +1,7 @@
 { config, pkgs, ... }: {
 
+  nixpkgs = { config.allowUnfree = true; };
+
   nix = {
 
     # Save space by hardlinking store files

--- a/users/nik.nix
+++ b/users/nik.nix
@@ -5,8 +5,12 @@
     home = "/home/nik";
     extraGroups = [ "wheel" ]; # Enable ‘sudo’ for the user.
     shell = pkgs.zsh;
-    openssh.authorizedKeys.keyFiles =
-      [ (builtins.fetchurl { url = "https://github.com/mayniklas.keys"; }) ];
+    openssh.authorizedKeys.keyFiles = [
+      (builtins.fetchurl {
+        url = "https://github.com/mayniklas.keys";
+        sha256 = "180458fg6i6sbqmyz18rb1hsq4226zdivqz86x9dwkv02fqvkygw";
+      })
+    ];
   };
 
   nix.allowedUsers = [ "nik" ];

--- a/users/root.nix
+++ b/users/root.nix
@@ -1,7 +1,11 @@
 { config, pkgs, lib, ... }: {
   # Define a user account. Don't forget to set a password with ‘passwd’.
   users.users.root = {
-    openssh.authorizedKeys.keyFiles =
-      [ (builtins.fetchurl { url = "https://github.com/mayniklas.keys"; }) ];
+    openssh.authorizedKeys.keyFiles = [
+      (builtins.fetchurl {
+        url = "https://github.com/mayniklas.keys";
+        sha256 = "180458fg6i6sbqmyz18rb1hsq4226zdivqz86x9dwkv02fqvkygw";
+      })
+    ];
   };
 }


### PR DESCRIPTION
- created flake.nix defining inputs/outputs
- modified krops.nix for flake deployment
- ssh keys fetched from GitHub now got a sha256 value
- moved module flakes.nix into nix-common.nix
- implemented flake synax checks through droneCI
- made water-on-fire flake ready
- made quinjet flake ready
- made the-bus flake ready